### PR TITLE
Completed Contracted Russian Braille table and fixed ignored characters.

### DIFF
--- a/tables/ru-ru-g1.ctb
+++ b/tables/ru-ru-g1.ctb
@@ -6,12 +6,13 @@
 #+language: ru
 #+type: literary
 #+dots: 6
-#+contraction: partial
+#+contraction: full
 #+grade:1
 #+direction: forward
 #
 #  Copyright (C) 2021 Ekaterina Anisimova <musicate@yandex.ru>
 #  Copyright (C) 2021-2022 Andrey Yakuboy <braille@yakuboy.ru>
+#  Copyright (C) 2022-2025 Dmitriy Lazarev
 #
 #  This file is part of liblouis.
 #
@@ -35,13 +36,11 @@
 # This table was created to make contracted braille more popular.
 # It may be not perfect because there're no data to test it.
 
-# Based on ru-litbrl.ctb which is included at the end of the file
-
 attribute consonant бвгджзйклмнпрстфхцчшщъь
 attribute vowel аеёиоуыэюя
 attribute muffled кпстфхцчшщ
 attribute voiced бвгджзлмнр
-attribute sch бвгджзйклмнопрстфхцчшщъыьэюя
+attribute shch бвгджзйклмнопрстфхцчшщъыьэюя
 
 punctuation ( 6-126
 punctuation ) 6-345
@@ -71,6 +70,18 @@ noback correct $D[";"$s] "\x2820; "
 noback correct $d[";"$s] "\x2820; "
 noback correct [%dropspaceafter$s] *
 
+# Workaround for not showing capitals
+capsletter 9
+begcapsword 9-9
+endcapsword 9-9
+noback pass2 @9 ?
+
+include ru-litbrl.ctb
+
+seqdelimiter -–—―−‐
+seqbeforechars ([{"“'‘«
+seqafterchars )]}"”'’».,;:!?…
+
 # Table I
 
 match (!(%[_>~]))+[вёзйклмнопрстучшщъыьэюя]+!(%_)+ ва - 3456
@@ -82,9 +93,9 @@ begmidword вё 23456
 always во 1236
 sufword вы 3
 partword го 12456
-before sch partword де 1346
-before sch partword дё 1346
-before sch begmidword щ 6-1346
+before shch partword де 1346
+before shch partword дё 1346
+before shch begmidword щ 6-1346
 endword щ 6-1346
 always до 256
 always за 356
@@ -141,8 +152,95 @@ always те 23
 partword ти 56
 always то 13456
 partword че 236
-midword ъ 3
-midword ь 3
+begmidword бъе 12-3-15
+begmidword бъё 12-3-16
+begmidword въе 2456-3-15
+begmidword дъе 145-3-15
+begmidword дъё 145-3-16
+begmidword дъю 145-3-1256
+begmidword зъя 1356-3-1246
+begmidword нъе 1345-3-15
+begmidword съе 234-3-15
+begmidword съё 234-3-16
+begmidword тъе 2345-3-15
+begmidword тъё 2345-3-16
+begmidword бье 12-3-15  
+begmidword бьё 12-3-16  
+begmidword бью 12-3-1256  
+begmidword бья 12-3-1246  
+begmidword вье 2456-3-15  
+begmidword вьё 2456-3-16  
+begmidword вью 2456-3-1256  
+begmidword вья 2456-3-1246  
+begmidword гье 1245-3-15  
+begmidword гьё 1245-3-16  
+begmidword гью 1245-3-1256  
+begmidword гья 1245-3-1246  
+begmidword дье 145-3-15  
+begmidword дьё 145-3-16  
+begmidword дью 145-3-1256  
+begmidword дья 145-3-1246  
+begmidword кье 13-3-15  
+begmidword кьё 13-3-16  
+begmidword кью 13-3-1256  
+begmidword кья 13-3-1246
+begmidword мье 134-3-15  
+begmidword мьё 134-3-16  
+begmidword мью 134-3-1256  
+begmidword мья 134-3-1246  
+begmidword нье 1345-3-15  
+begmidword ньё 1345-3-16  
+begmidword нью 1345-3-1256  
+begmidword нья 1345-3-1246  
+begmidword пье 1234-3-15  
+begmidword пьё 1234-3-16  
+begmidword пью 1234-3-1256  
+begmidword пья 1234-3-1246  
+begmidword рье 1235-3-15  
+begmidword рьё 1235-3-16  
+begmidword рью 1235-3-1256  
+begmidword рья 1235-3-1246  
+begmidword сье 234-3-15  
+begmidword сьё 234-3-16  
+begmidword сью 234-3-1256  
+begmidword сья 234-3-1246  
+begmidword тье 2345-3-15  
+begmidword тьё 2345-3-16  
+begmidword тью 2345-3-1256  
+begmidword тья 2345-3-1246  
+begmidword фье 124-3-15  
+begmidword фьё 124-3-16  
+begmidword фью 124-3-1256  
+begmidword фья 124-3-1246  
+begmidword хье 125-3-15  
+begmidword хьё 125-3-16  
+begmidword хью 125-3-1256  
+begmidword хья 125-3-1246
+midendword ьб 3-12
+midendword ьв 3-2456
+midendword ьг 3-1245
+midendword ьд 3-145
+midendword ьж 3-245
+midendword ьз 3-1356
+midendword ьк 3-13
+midendword ьл 3-123
+midendword ьм 3-134
+midendword ьн 3-1345
+midendword ьп 3-1234
+midendword ьр 3-1235
+midendword ьс 3-234
+midendword ьт 3-2345
+midendword ьф 3-124
+midendword ьх 3-125
+midendword ьц 3-14
+endword бь 12-3
+endword вь 2456-3
+endword дь 145-3
+endword зь 1356-3
+endword мь 134-3
+endword нь 1345-3
+endword пь 1234-3
+endword рь 1235-3
 
 # Table II
 
@@ -449,8 +547,8 @@ word вами 2456-124
 word весь 23456
 word ь 6-23456
 word Ь 6-23456
-always всё 156
 always все 156
+always всё 156
 word ш 6-156
 word Ш 6-156
 word всю 156-1256
@@ -688,22 +786,105 @@ word частично 12345-126
 word чрезвычайно 12345-1356-126
 word характерно 125-1235-126
 
+#Table VIII
+
+before muffled begword ис 36
+begword предб 1234-12
+begword предбуд 1234-12
+begword предбывш 1234-12
+begword предв 1234-2456
+begword предво 1234-1236
+begword предвсё 1234-156
+begword предвсе 1234-156
+begword предва 1234-3456
+begword предве 1234-23456
+begword предг 1234-1245
+begword предго 1234-12456
+begword предм 1234-134
+begword предмог 1234-134
+begword предме 1234-146
+begword предмож 1234-134
+begword предми 1234-124
+begword предн 1234-1345
+begword предна 1234-345
+begword предне 1234-16
+begword предни 1234-34
+begword предно 1234-126
+begword предност 1234-25
+begword предп 1234-1234
+begword предпо 1234-235
+begword предст 1234-25
+begword предста 1234-25
+begword разб 1235-12
+begword разбуд 1235-12
+begword разг 1235-1245
+begword разго 1235-12456
+begword разе 1235-15
+begword разева 1235-3456
+begword разени 1235-34
+begword разз 1235-1356
+begword раза 1235-356
+begword разл 1235-123
+begword разли 1235-35
+begword разль 1235-2356
+begword разла 1235-4
+begword разле 1235-26
+begword разло 1235-456
+begword разм 1235-134
+begword размог 1235-134
+begword разме 1235-146
+begword размож 1235-134
+begword разми 1235-124
+begword разн 1235-1345
+begword разна 1235-345
+begword разне 1235-16
+begword разни 1235-34
+begword разно 1235-126
+begword разност 1235-25
+begword разр 1235-1235
+begword разра 1235-45
+begword разре 1235-2
+begword разри 1235-5
+begword разро 1235-12356
+begword разя 1235-1246
+begword разявить 1235-1246-23456
+begword разяв 1235-1246
+begword разяви 1235-1246
+begword разявит 1235-1246-2345
+begword разявят 1235-1246-2345
+begword раск 1235-13
+begword раско 1235-1456
+begword раска 1235-346
+begword раскотор 1235-13
+begword раски 1235-246
+begword расп 1235-1234
+begword распо 1235-235
+begword расс 1235-234
+begword расст 1235-25
+begword расста 1235-25
+begword расственн 1235-25-1345
+begword расственност 1235-25-25
+begword расска 1235-346
+begword расски 1235-246
+begword расско 1235-1456
+begword расф 1235-124
+begword расх 1235-125
+begword расхоч 1235-125
+begword расхоте 1235-125
+begword расхоти 1235-125
+begword расхотя 1235-125
+begword расц 1235-14
+begword расч 1235-12345
+begword расче 1235-236
+begword расческ 1235-6-13
+begword расчайш 1235-6-12345
+begword расш 1235-156
+begword расщ 1235-1346
+midword ска 346
+midendword ски 246
+midword ско 1456
+
 # Abbreviations that shouldn't be contracted
 
 word вос 2456-135-234
 word нис 1345-24-234
-
-# Include ru-litbrl.ctb
-
-include ru-litbrl.ctb
-
-# Workaround for not showing capitals
-capsletter 9
-begcapsword 9-9
-endcapsword 9-9
-noback pass2 @9 ?
-
-# Need to come after ru-litbrl.ctb to avoid "Sequence delimiter character undefined" error
-seqdelimiter -–—―−‐
-seqbeforechars ([{"“'‘«
-seqafterchars )]}"”'’».,;:!?…


### PR DESCRIPTION
1. Added Table VIII at the end of Table VII to complete the Contracted Russian Braille table in accordance with Grade 1 rules.  
2. Added ё variants to existing signs to make them inclusive (всё, нё, лё).  
3. Fixed dot 3 representation for ъ and ь in all midword/endword cases where these letters were ignored.  
4. Changed all instances of sch to shch like "before shch щ" because щ in English letters is shch.
4. Changed status from partial to full since all 8 tables of the code are now present.